### PR TITLE
refactor: stop HttpServer manually instead of interruption

### DIFF
--- a/src/main/kotlin/net/ccbluex/netty/http/HttpServer.kt
+++ b/src/main/kotlin/net/ccbluex/netty/http/HttpServer.kt
@@ -61,7 +61,7 @@ class HttpServer {
         internal val logger = LogManager.getLogger("HttpServer")
     }
 
-    fun middleware(middleware: Middleware) {
+    fun middleware(middleware: Middleware) = apply {
         middlewares += middleware
     }
 

--- a/src/test/kotlin/HttpMiddlewareServerTest.kt
+++ b/src/test/kotlin/HttpMiddlewareServerTest.kt
@@ -7,9 +7,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.junit.jupiter.api.*
-import java.io.File
-import java.nio.file.Files
-import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -21,7 +18,7 @@ import kotlin.test.assertTrue
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HttpMiddlewareServerTest {
 
-    private lateinit var serverThread: Thread
+    private lateinit var server: HttpServer
     private val client = OkHttpClient()
 
     /**
@@ -32,9 +29,7 @@ class HttpMiddlewareServerTest {
     @BeforeAll
     fun initialize() {
         // Start the HTTP server in a separate thread
-        serverThread = thread {
-            startHttpServer()
-        }
+        server = startHttpServer()
 
         // Allow the server some time to start
         Thread.sleep(1000)
@@ -46,14 +41,14 @@ class HttpMiddlewareServerTest {
      */
     @AfterAll
     fun cleanup() {
-        serverThread.interrupt()
+        server.stop()
     }
 
     /**
      * This function starts the HTTP server with routing configured for
      * different difficulty levels.
      */
-    private fun startHttpServer() {
+    private fun startHttpServer(): HttpServer {
         val server = HttpServer()
 
         server.routeController.apply {
@@ -74,6 +69,7 @@ class HttpMiddlewareServerTest {
         }
 
         server.start(8080)  // Start the server on port 8080
+        return server
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/src/test/kotlin/HttpServerTest.kt
+++ b/src/test/kotlin/HttpServerTest.kt
@@ -9,7 +9,6 @@ import okhttp3.Response
 import org.junit.jupiter.api.*
 import java.io.File
 import java.nio.file.Files
-import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -22,7 +21,7 @@ import kotlin.test.assertTrue
 class HttpServerTest {
 
     private lateinit var folder: File
-    private lateinit var serverThread: Thread
+    private lateinit var server: HttpServer
     private val client = OkHttpClient()
 
     /**
@@ -44,9 +43,7 @@ class HttpServerTest {
         File(subFolder, "index.html").writeText("Hello, World!")
 
         // Start the HTTP server in a separate thread
-        serverThread = thread {
-            startHttpServer(folder)
-        }
+        server = startHttpServer(folder)
 
         // Allow the server some time to start
         Thread.sleep(1000)
@@ -58,7 +55,7 @@ class HttpServerTest {
      */
     @AfterAll
     fun cleanup() {
-        serverThread.interrupt()
+        server.stop()
         folder.deleteRecursively() // Clean up the temporary folder
     }
 
@@ -66,7 +63,7 @@ class HttpServerTest {
      * This function starts the HTTP server with routing configured for
      * different difficulty levels.
      */
-    private fun startHttpServer(folder: File) {
+    private fun startHttpServer(folder: File): HttpServer {
         val server = HttpServer()
 
         server.routeController.apply {
@@ -97,6 +94,7 @@ class HttpServerTest {
         }
 
         server.start(8080)  // Start the server on port 8080
+        return server
     }
 
     @Suppress("UNUSED_PARAMETER")


### PR DESCRIPTION
This refactoring makes HttpServer#start not blocking anymore. And now we should call HttpServer#stop to stop this server (instead of interrupting).

This can make it easier to be used in OAuthServer(mc-authlib) and OAuthClient(LiquidBounce).
